### PR TITLE
Added support for unquoted String Values

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -524,7 +524,24 @@ Private Function json_ParseValue(json_String As String, ByRef json_Index As Long
     Case """", "'"
         json_ParseValue = json_ParseString(json_String, json_Index)
     Case Else
-        If VBA.Mid$(json_String, json_Index, 4) = "true" Then
+        'Start - Unquoted string (asopenag) -----------------------------------------------------------------------------------
+        If JsonOptions.AllowUnquotedKeys Then
+            Dim json_Char As String
+            Do While json_Index > 0 And json_Index <= Len(json_String)
+                json_Char = VBA.Mid$(json_String, json_Index, 1)
+                If (json_Char <> " ") And (json_Char <> ",") And (json_Char <> "}") And (json_Char <> "]") Then
+                    json_ParseValue = json_ParseValue & json_Char
+                    json_Index = json_Index + 1
+                Else  'once finished:
+                    If LCase(json_ParseValue) = "true" Then json_ParseValue = True
+                    If LCase(json_ParseValue) = "false" Then json_ParseValue = False
+                    If LCase(json_ParseValue) = "null" Then json_ParseValue = Null
+                    If IsNumeric(json_ParseValue) Then json_ParseValue = VBA.Val(json_ParseValue)
+                    Exit Do
+                End If
+            Loop
+        'End - Unquoted string (asopenag) -----------------------------------------------------------------------------------
+        ElseIf VBA.Mid$(json_String, json_Index, 4) = "true" Then
             json_ParseValue = True
             json_Index = json_Index + 4
         ElseIf VBA.Mid$(json_String, json_Index, 5) = "false" Then


### PR DESCRIPTION
I've found lately JSONs with unquoted String values (it seems to be called [relaxed json](http://www.relaxedjson.org/)), so I've updated the code to support those:

In this version, if you set the setting `JsonOptions.AllowUnquotedKeys` to `True` it will also allow unquoted Strings. Unquoted Strings (in this version) end once we find a space, a coma, a "}" or a "]".

Notice that this will capture the true/false/null/numbers as strings (not having the quotes to identify the strings, all are a potential Strings), so we check them afterwards and:
- If `IsNumeric()` we convert the value back to number using `VBA.Val()`.
- If  = "null" -> `Null`
- If = "true" / "false" -> `True` / `False`

**Next steps:** We should clarify the setting `JsonOptions.AllowUnquotedKeys` : (a) rename it to clarify it works for both key and values or (b) create a new setting to allow unquote key/values separately.